### PR TITLE
Fix storage headers

### DIFF
--- a/components/blocks/About.vue
+++ b/components/blocks/About.vue
@@ -94,7 +94,7 @@
 <script>
 import DTOC from '@/components/base/DTableOfContents.vue';
 import DPersonCard from '@/components/base/DPersonCard.vue';
-import urlize from '@/utils';
+import { urlize } from '@/utils';
 
 export default {
   components: {

--- a/components/blocks/DirsToCardSections.vue
+++ b/components/blocks/DirsToCardSections.vue
@@ -28,7 +28,7 @@
 <script>
 import DTOC from '@/components/base/DTableOfContents.vue';
 import CardGroup from '@/components/blocks/CardGroup.vue';
-import urlize from '@/utils';
+import { urlize } from '@/utils';
 
 export default {
   components: {

--- a/components/blocks/FilesToSections.vue
+++ b/components/blocks/FilesToSections.vue
@@ -32,7 +32,7 @@
 
 <script>
 import DTOC from '@/components/base/DTableOfContents.vue';
-import urlize from '@/utils'
+import { urlize } from '@/utils'
 
 export default {
   components: {

--- a/components/storage/ComparisonCards.vue
+++ b/components/storage/ComparisonCards.vue
@@ -16,7 +16,7 @@
       class="mx-3 my-3 px-3"
     >
       <template #header>
-        <h2 class="title is-size-4">{{ service.service }}</h2>
+        <h2 class="title is-size-4">{{ service.name }}</h2>
       </template>
 
       <template #content>

--- a/components/storage/ComparisonTable.vue
+++ b/components/storage/ComparisonTable.vue
@@ -6,10 +6,10 @@
           <th />
           <th
             v-for="service in services"
-            :key="'header-' + service.service"
+            :key="'header-' + service.name"
             class="header-cell"
           >
-            {{ humanize(service.service) }}
+            {{ humanize(service.name) }}
           </th>
         </tr>
       </thead>
@@ -38,7 +38,7 @@
 
 <script>
 import ComparisonCellContent from '@/components/storage/ComparisonCellContent.vue';
-import humanize from '@/utils'; 
+import { humanize } from '@/utils'; 
 
 export default {
   components: {

--- a/components/storage/ServiceSelection.vue
+++ b/components/storage/ServiceSelection.vue
@@ -56,7 +56,7 @@
 
 <script>
 import DModal from '@/components/base/DModal.vue';
-import humanize from '@/utils';
+import { humanize } from '@/utils';
 
 export default {
   components: {

--- a/pages/_main/_category/index.vue
+++ b/pages/_main/_category/index.vue
@@ -42,8 +42,7 @@
 
 <script>
 import DHero from '@/components/base/DHero.vue';
-import urlize from '@/utils';
-import humanize from '@/utils';
+import { humanize, urlize } from '@/utils';
 
 export default {
   components: {


### PR DESCRIPTION
This is a baby PR that fixes the missing service name title/headers on the storage app comparison table, cards, and services section.