### PR TITLE
fix: investigators icon

### DIFF
--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -164,7 +164,7 @@
                   :key="contributorType"
                 >
                   <div>
-                    <i
+                    <i v-if="contributorArray"
                       :class="[
                         'mdi',
                         contributorIcon[contributorType],


### PR DESCRIPTION
tiny PR to switch off brain icon for projects where there are no investigators