### PR TITLE
fix: banner content path

### DIFF
--- a/components/base/PageHeader.vue
+++ b/components/base/PageHeader.vue
@@ -52,7 +52,7 @@ export default {
     };
   },
   async fetch() {
-    this.banners = await this.$content('home', 'banners').fetch();
+    this.banners = await this.$content('banners').fetch();
     const res = await fetch('/_ghapi/status');
     this.status = await res.json();
   },


### PR DESCRIPTION
Fixes the error on the banner path.

Do we still need the covid banner... probably not.  But that's a problem for the content repo