### PR TITLE
fix: make alpha a bit more opaque for home hero

### DIFF
--- a/components/base/DHero.vue
+++ b/components/base/DHero.vue
@@ -71,7 +71,7 @@ export default {
   background-image: var(--ccv-image);
 
   .hero-text {
-    background-color: rgba(0, 0, 0, 0.3);
+    background-color: rgba(0, 0, 0, 0.45);
     padding: 1rem;
     margin: 0 -1rem;
   }


### PR DESCRIPTION
I think with the winter photo the contrast wasn't quite good enough, this makes the text's background a bit more opaque.