### PR TITLE
fix: add oit to sort order for about page

### DIFF
--- a/components/base/Footer.vue
+++ b/components/base/Footer.vue
@@ -131,6 +131,9 @@
           <h2 class="">About</h2>
         </li>
         <li class="">
+          <a href="/about#office-of-information-technology" tabindex="0"> Office of Information Technology </a>
+        </li>
+        <li class="">
           <a href="/about#mission" tabindex="0"> Mission </a>
         </li>
         <li class="">

--- a/components/base/Navbar.vue
+++ b/components/base/Navbar.vue
@@ -185,6 +185,15 @@
           <div class="navbar-dropdown">
             <div class="navbar-item">
               <nuxt-link
+                to="/about#oit"
+                tabindex="0"
+                @click.native="handleClick"
+              >
+                Office of Information Techology
+              </nuxt-link>
+            </div>
+            <div class="navbar-item">
+              <nuxt-link
                 to="/about#mission"
                 tabindex="0"
                 @click.native="handleClick"

--- a/components/base/Navbar.vue
+++ b/components/base/Navbar.vue
@@ -185,11 +185,11 @@
           <div class="navbar-dropdown">
             <div class="navbar-item">
               <nuxt-link
-                to="/about#oit"
+                to="/about#office-of-information-technology"
                 tabindex="0"
                 @click.native="handleClick"
               >
-                Office of Information Techology
+                Office of Information Technology
               </nuxt-link>
             </div>
             <div class="navbar-item">

--- a/components/blocks/About.vue
+++ b/components/blocks/About.vue
@@ -141,6 +141,7 @@ export default {
     sortedData() {
       const ogData = [...this.data];
       const sortOrder = [
+        'oit',
         'mission',
         'teams',
         'people',


### PR DESCRIPTION
This is a tiny PR that accompanies the OIT section PR from the `-content` repo. In particular, it adds `oit` to the sorting order of section in the `About` page. 