### PR TITLE
build: cache images for a week

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,16 @@
           "source": "**",
           "function": "ssrapp"
         }
+      ],
+      "headers": [ {
+        "source": "**/*.@(jpg|jpeg|gif|png)",
+        "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "max-age=604800"
+            }
+          ]
+        }
       ]
     },
     "emulators": {


### PR DESCRIPTION
The default caching time on the browser is 1 hour.  This adds a header to cache images for a week instead.  We don't have many images and they are mostly things that should change very infrequently, so this should help reduce our firebase hosting downloads usage.