### PR TITLE
feat: add multiple search bars

### DIFF
--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -82,6 +82,9 @@
       </DCard>
     </div>
     <div v-else class="container">
+      <div class="multiselect-header mt-4 mb-1 is-flex is-flex-wrap-wrap is-justify-content-space-evenly">
+        Filter cards by:
+      </div>
       <div
         class="
           dropdown
@@ -101,7 +104,7 @@
               :clear-on-select="false"
               :preserve-search="true"
               :multiple="true"
-              placeholder="Select tags to filter by"
+              :placeholder="cat"
               :allow-empty="true"
             >
             </multiselect>
@@ -110,6 +113,9 @@
             </button>
           </div>
         </div>
+      </div>
+      <div class="multiselect-header mt-3 mb-1 is-flex is-flex-wrap-wrap is-justify-content-space-evenly">
+        Sort cards by:
       </div>
       <div
         class="
@@ -404,6 +410,10 @@ export default {
 
 .multiselect {
   min-width: 225px;
+}
+
+.multiselect-header {
+  font-weight: bold;
 }
 
 .link-button {

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -90,12 +90,12 @@
       >
         <div class="mb-1 is-flex">
           <div
-            v-for="cat in tagCategories"
+            v-for="(cat, index) in tagCategories"
             :key="cat"
             class="mb-1 mr-4 is-flex"
           >
             <multiselect
-              v-model="searchGroup"
+              v-model="searchGroup[index]"
               :options="cardTags(cat)"
               :close-on-select="true"
               :clear-on-select="false"
@@ -305,9 +305,10 @@ export default {
     },
     sortedArray() {
       let filtered = this.filteredData;
-      if (this.searchGroup.length > 0) {
+      const flatSearchGroup = this.searchGroup.flat();
+      if (flatSearchGroup.length > 0) {
         filtered = filtered.filter((card) => {
-          return this.searchGroup.some((tag) =>
+          return flatSearchGroup.some((tag) =>
             this.tags.some((tagType) => {
               const tags = card[tagType] ?? [];
               return tags.includes(tag);
@@ -382,6 +383,9 @@ export default {
         return undefined;
       }
     },
+    // populateSearchGroup(cat) {
+    //   return this.searchGroup.push(this.searchGroup[cat])
+    // }
   },
 };
 </script>

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -82,7 +82,7 @@
       </DCard>
     </div>
     <div v-else class="container">
-      <div>{{ searchGroup }}</div>
+      <div>{{ searchGroup}}</div>
       <div
         class="
           multiselect-header
@@ -110,6 +110,8 @@
             </div>
             <multiselect
               v-model="searchGroup[index]"
+              label="name"
+              track-by="tagCode"
               :options="cardTags(cat)"
               :close-on-select="true"
               :clear-on-select="false"
@@ -119,12 +121,14 @@
               :allow-empty="true"
             >
             </multiselect>
-            <button class="ml-1 button is-normal is-warning" @click="clearAll">
-              Clear Filters
-            </button>
           </div>
         </div>
       </div>
+      <div class="has-text-centered">
+        <button class="ml-1 button is-normal is-warning" @click="clearAll">
+          Clear Filters
+        </button>
+    </div>
       <div
         class="
           multiselect-header
@@ -330,28 +334,27 @@ export default {
     },
     sortedArray() {
       let filtered = this.filteredData;
-      const flatSearchGroup = this.searchGroup.flat();
       if (this.searchGroup.length === 1) {
         filtered = filtered.filter((card) => {
-          return flatSearchGroup.some((tag) =>
+          return this.searchGroup.flat().map(name => name.tagCode).some((tag) =>
             this.tags.some((tagType) => {
               const tags = card[tagType] ?? [];
               return tags.includes(tag);
-            })
-          );
+              })
+            );
         });
       } else if (this.searchGroup.length > 1) {
         for (let i = 0; i < this.searchGroup.length; i++) {
           filtered = filtered.filter((card) => {
-            return this.searchGroup[i].some((tag) =>
+            return this.searchGroup[i].map(name => name.tagCode).some((tag) =>
               this.tags.some((tagType) => {
                 const tags = card[tagType] ?? [];
                 return tags.includes(tag);
-              })
-            );
+                })
+              );
           });
         }
-        this.searchGroup.reduce(this.common);
+        this.searchGroup.reduce(this.common).flat();
       }
 
       // Sort by title alphabetical order
@@ -402,8 +405,14 @@ export default {
         .map((tagType) => this.filteredData.map((card) => card[tagType]))
         .flat(2)
         .filter((e) => e);
-      const res = tags.filter((tag, index) => tags.indexOf(tag) === index).sort();
-      return res.map(item => humanizeHero(item))
+      const names = tags.filter((tag, index) => tags.indexOf(tag) === index).sort();
+      const tagCodes = names.map(item => humanizeHero(item))
+      const res = []
+      names.forEach((n, index) => {
+        const code = tagCodes[index];
+        res.push({name: code, tagCode: n})
+      });
+      return res;
     },
     clearAll() {
       this.searchGroup = [];

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -82,7 +82,6 @@
       </DCard>
     </div>
     <div v-else class="container">
-      <div>{{ searchGroup}}</div>
       <div
         class="
           multiselect-header
@@ -334,17 +333,8 @@ export default {
     },
     sortedArray() {
       let filtered = this.filteredData;
-      if (this.searchGroup.length === 1) {
-        filtered = filtered.filter((card) => {
-          return this.searchGroup.flat().map(name => name.tagCode).some((tag) =>
-            this.tags.some((tagType) => {
-              const tags = card[tagType] ?? [];
-              return tags.includes(tag);
-              })
-            );
-        });
-      } else if (this.searchGroup.length > 1) {
-        for (let i = 0; i < this.searchGroup.length; i++) {
+      for (let i=0; i < this.searchGroup.length; i++) {
+        if (this.searchGroup[i] && this.searchGroup[i].length > 0) {
           filtered = filtered.filter((card) => {
             return this.searchGroup[i].map(name => name.tagCode).some((tag) =>
               this.tags.some((tagType) => {
@@ -353,8 +343,7 @@ export default {
                 })
               );
           });
-        }
-        this.searchGroup.reduce(this.common).flat();
+        };
       }
 
       // Sort by title alphabetical order

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -98,7 +98,7 @@
           is-flex is-flex-wrap-wrap is-justify-content-space-evenly
         "
       >
-        <div class="mb-1 is-flex">
+        <div class="mb-1 is-flex is-justify-content-space-evenly is-flex-wrap-wrap">
           <div
             v-for="(cat, index) in tagCategories"
             :key="cat"

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -105,7 +105,9 @@
             :key="cat"
             class="mb-1 mr-4"
           >
-            <div class="multiselect-header">{{cat[0].toUpperCase() + cat.substring(1)}}</div>
+            <div class="multiselect-header">
+              {{ cat[0].toUpperCase() + cat.substring(1) }}
+            </div>
             <multiselect
               v-model="searchGroup[index]"
               :options="cardTags(cat)"
@@ -113,7 +115,7 @@
               :clear-on-select="false"
               :preserve-search="true"
               :multiple="true"
-              placeholder="Select one or more filters"
+              placeholder="Select one or more"
               :allow-empty="true"
             >
             </multiselect>
@@ -265,12 +267,12 @@ export default {
     ascending: true,
     sortBy: [],
     searchGroup: [],
-    tags: ['tags', 'groups', 'languages', 'department', 'active'],
+    tags: ['department', 'groups', 'tags', 'languages', 'active'],
     tagColors: {
-      tags: 'is-link',
-      groups: 'is-yellow',
-      languages: 'is-info',
       department: 'is-yellow',
+      groups: 'is-yellow',
+      tags: 'is-link',
+      languages: 'is-info',
       active: 'is-info',
     },
     contributorIcon: {

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -89,21 +89,34 @@
         "
       >
         <div class="mb-1 is-flex">
-          <multiselect
-            v-model="searchGroup"
-            :options="cardTags"
-            :close-on-select="true"
-            :clear-on-select="false"
-            :preserve-search="true"
-            :multiple="true"
-            placeholder="Select tags to filter by"
-            :allow-empty="true"
+          <div
+            v-for="cat in tagCategories"
+            :key="cat"
+            class="mb-1 mr-4 is-flex"
           >
-          </multiselect>
-          <button class="ml-1 button is-normal is-warning" @click="clearAll">
-            Clear Filters
-          </button>
+            <multiselect
+              v-model="searchGroup"
+              :options="cardTags(cat)"
+              :close-on-select="true"
+              :clear-on-select="false"
+              :preserve-search="true"
+              :multiple="true"
+              placeholder="Select tags to filter by"
+              :allow-empty="true"
+            >
+            </multiselect>
+            <button class="ml-1 button is-normal is-warning" @click="clearAll">
+              Clear Filters
+            </button>
+          </div>
         </div>
+      </div>
+      <div
+        class="
+          dropdown
+          is-flex is-flex-wrap-wrap is-justify-content-space-evenly
+        "
+      >
         <div class="mb-1 is-flex">
           <multiselect
             v-model="sortBy"
@@ -257,12 +270,19 @@ export default {
       });
       return f;
     },
-    cardTags() {
-      const tags = this.tags
-        .map((tagType) => this.filteredData.map((card) => card[tagType]))
-        .flat(2)
-        .filter((e) => e);
-      return tags.filter((tag, index) => tags.indexOf(tag) === index).sort();
+    tagCategories() {
+      // create array of tag categories (tags, departments, languages, etc. for each our work type)
+      const tagCats = [];
+      for (let i = 0; i < this.tags.length; i++) {
+        const catExists = this.filteredData.some((o) => {
+          // eslint-disable-next-line no-prototype-builtins
+          return o.hasOwnProperty(this.tags[i]);
+        });
+        if (catExists) {
+          tagCats.push(this.tags[i]);
+        }
+      }
+      return tagCats;
     },
     sortByOptions() {
       // eslint-disable-next-line no-prototype-builtins
@@ -336,6 +356,13 @@ export default {
     },
   },
   methods: {
+    cardTags(category) {
+      const tags = [category]
+        .map((tagType) => this.filteredData.map((card) => card[tagType]))
+        .flat(2)
+        .filter((e) => e);
+      return tags.filter((tag, index) => tags.indexOf(tag) === index).sort();
+    },
     clearAll() {
       this.searchGroup = [];
     },

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -82,7 +82,15 @@
       </DCard>
     </div>
     <div v-else class="container">
-      <div class="multiselect-header mt-4 mb-1 is-flex is-flex-wrap-wrap is-justify-content-space-evenly">
+      <div>{{ searchGroup }}</div>
+      <div
+        class="
+          multiselect-header
+          mt-4
+          mb-1
+          is-flex is-flex-wrap-wrap is-justify-content-space-evenly
+        "
+      >
         Filter cards by:
       </div>
       <div
@@ -95,8 +103,9 @@
           <div
             v-for="(cat, index) in tagCategories"
             :key="cat"
-            class="mb-1 mr-4 is-flex"
+            class="mb-1 mr-4"
           >
+            <div class="multiselect-header">{{cat[0].toUpperCase() + cat.substring(1)}}</div>
             <multiselect
               v-model="searchGroup[index]"
               :options="cardTags(cat)"
@@ -104,7 +113,7 @@
               :clear-on-select="false"
               :preserve-search="true"
               :multiple="true"
-              :placeholder="cat"
+              placeholder="Select one or more filters"
               :allow-empty="true"
             >
             </multiselect>
@@ -114,7 +123,14 @@
           </div>
         </div>
       </div>
-      <div class="multiselect-header mt-3 mb-1 is-flex is-flex-wrap-wrap is-justify-content-space-evenly">
+      <div
+        class="
+          multiselect-header
+          mt-5
+          mb-1
+          is-flex is-flex-wrap-wrap is-justify-content-space-evenly
+        "
+      >
         Sort cards by:
       </div>
       <div
@@ -312,7 +328,7 @@ export default {
     sortedArray() {
       let filtered = this.filteredData;
       const flatSearchGroup = this.searchGroup.flat();
-      if (flatSearchGroup.length > 0) {
+      if (this.searchGroup.length === 1) {
         filtered = filtered.filter((card) => {
           return flatSearchGroup.some((tag) =>
             this.tags.some((tagType) => {
@@ -321,6 +337,18 @@ export default {
             })
           );
         });
+      } else if (this.searchGroup.length > 1) {
+        for (let i = 0; i < this.searchGroup.length; i++) {
+          filtered = filtered.filter((card) => {
+            return this.searchGroup[i].some((tag) =>
+              this.tags.some((tagType) => {
+                const tags = card[tagType] ?? [];
+                return tags.includes(tag);
+              })
+            );
+          });
+        }
+        this.searchGroup.reduce(this.common);
       }
 
       // Sort by title alphabetical order
@@ -391,9 +419,9 @@ export default {
         return undefined;
       }
     },
-    // populateSearchGroup(cat) {
-    //   return this.searchGroup.push(this.searchGroup[cat])
-    // }
+    common(a, b) {
+      return b.filter(Set.prototype.has.bind(new Set(a)));
+    },
   },
 };
 </script>

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -251,6 +251,7 @@
 <script>
 import DCard from '@/components/base/DCard.vue';
 import Multiselect from 'vue-multiselect';
+import { humanizeHero } from '@/utils';
 
 export default {
   components: {
@@ -395,12 +396,14 @@ export default {
     },
   },
   methods: {
+    humanizeHero,
     cardTags(category) {
       const tags = [category]
         .map((tagType) => this.filteredData.map((card) => card[tagType]))
         .flat(2)
         .filter((e) => e);
-      return tags.filter((tag, index) => tags.indexOf(tag) === index).sort();
+      const res = tags.filter((tag, index) => tags.indexOf(tag) === index).sort();
+      return res.map(item => humanizeHero(item))
     },
     clearAll() {
       this.searchGroup = [];

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -338,13 +338,6 @@ export default {
       } else if (this.sortBy.name === 'Active') {
         // Sort by active
         filtered.sort((a, b) => {
-          // // eslint-disable-next-line no-prototype-builtins
-          // return a.hasOwnProperty('active')
-          //   ? -1
-          //   : // eslint-disable-next-line no-prototype-builtins
-          //   b.hasOwnProperty('active')
-          //     ? 1
-          //     : 0;
           const fa = a.active;
           const fb = b.active;
           if (fa < fb) {

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -262,7 +262,7 @@ export default {
       f.forEach(function (obj) {
         for (const key in obj) {
           if (obj[key] === false) {
-            delete obj[key];
+            obj[key] = ['inactive'];
           } else if (obj[key] === true) {
             obj[key] = ['active'];
           }
@@ -338,13 +338,22 @@ export default {
       } else if (this.sortBy.name === 'Active') {
         // Sort by active
         filtered.sort((a, b) => {
-          // eslint-disable-next-line no-prototype-builtins
-          return a.hasOwnProperty('active')
-            ? -1
-            : // eslint-disable-next-line no-prototype-builtins
-            b.hasOwnProperty('active')
-              ? 1
-              : 0;
+          // // eslint-disable-next-line no-prototype-builtins
+          // return a.hasOwnProperty('active')
+          //   ? -1
+          //   : // eslint-disable-next-line no-prototype-builtins
+          //   b.hasOwnProperty('active')
+          //     ? 1
+          //     : 0;
+          const fa = a.active;
+          const fb = b.active;
+          if (fa < fb) {
+            return -1;
+          }
+          if (fa > fb) {
+            return 1;
+          }
+          return 0;
         });
       }
 


### PR DESCRIPTION
- [x]  added and formatted search bars (feedback on formatting would be appreciated)
- [x] fix issue where when you select a tag from one dropdown, all dropdowns get populated with the tag
- [x] add inactive tag
- [x] change prompts inside filter dropdowns to display tags, departments, languages, etc.
- [x] dropdown logic
- [x] one or multiple clear filter buttons?
- [x] dropdown order to departments first and tags last
- [x] add dropdown titles outside of dropdown 
- [x] human readable dropdown options
- [x] fix: removing tags from dropdown behavior
- [x] fix: each dropdown does not work independently - they all have to selected in order currently
- [x] computational biology is a department and a tag - is this desireable?
- [x] mobile view needs flexbox 