### PR TITLE
chore: update versions of node and github actions for ci build

### DIFF
--- a/.github/workflows/firebase-prod-merge.yml
+++ b/.github/workflows/firebase-prod-merge.yml
@@ -10,14 +10,14 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '18'
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/firebase-prod-merge.yml
+++ b/.github/workflows/firebase-prod-merge.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
       - name: Cache node modules
         uses: actions/cache@v3
         env:

--- a/.github/workflows/firebase-qa-pull-request.yml
+++ b/.github/workflows/firebase-qa-pull-request.yml
@@ -4,14 +4,14 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/firebase-qa-pull-request.yml
+++ b/.github/workflows/firebase-qa-pull-request.yml
@@ -9,7 +9,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
       - name: Cache node modules
         uses: actions/cache@v3
         env:


### PR DESCRIPTION
This PR bumps the version of Node used in our GitHub Actions to be Node 16, which [is the latest version supported by Nuxt 2](https://github.com/nuxt/nuxt/issues/10844). It also bumps the versions of several actions to be `v3`. 