### PR TITLE
ci: fix out-of-memory error in production deploy workflow

### DIFF
--- a/.github/workflows/firebase-prod-merge.yml
+++ b/.github/workflows/firebase-prod-merge.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build
         # Make sure content is tracking main and up-to date, then builds and deploys
         run: |
+          export NODE_OPTIONS="--max_old_space_size=4096"
           npm run generate
           npm run build
           npm run predeploy


### PR DESCRIPTION
This fixes the out-of-memory error we are seeing on the production deploy workflow. This is the same fix that we used for the QA workflow. 