### PR TITLE
feat: sort people by team

### DIFF
--- a/components/base/AuthorCard.vue
+++ b/components/base/AuthorCard.vue
@@ -18,7 +18,9 @@
               v-if="person.github_username"
               :href="'https://github.com/' + person.github_username"
               aria-label="information icon"
-              ><span class="icon"><i class="mdi mdi-github" /></span>
+              ><span class="icon is-large"
+                ><i class="mdi mdi-48px mdi-github"
+              /></span>
             </a>
             <a
               v-if="person.brown_directory_uuid"
@@ -27,7 +29,9 @@
                 person.brown_directory_uuid
               "
               aria-label="information icon"
-              ><span class="icon"><i class="mdi mdi-information" /></span>
+              ><span class="icon is-large"
+                ><i class="mdi mdi-48px mdi-email"
+              /></span>
             </a>
           </div>
         </template>

--- a/components/base/DPersonCard.vue
+++ b/components/base/DPersonCard.vue
@@ -30,7 +30,8 @@
       <footer class="content py-3 px-3">
         <h5>{{ name }}</h5>
         <p data-testid="title-team">
-          <small>{{ title }} | {{ team }}</small>
+          <small>{{ title }}</small>
+          <small v-scroll-to="'#our-teams'">{{ team }} | {{ subteam }}</small>
         </p>
         <slot name="icons" />
       </footer>
@@ -57,6 +58,10 @@ export default {
       required: true,
     },
     team: {
+      type: String,
+      required: true,
+    },
+    subteam: {
       type: String,
       required: true,
     },

--- a/components/base/DPersonCard.vue
+++ b/components/base/DPersonCard.vue
@@ -30,9 +30,9 @@
       <footer class="content py-3 px-3">
         <h5>{{ name }}</h5>
         <p data-testid="title-team">
-          <small>{{ title }}</small>
-          <small>{{ team }}</small>
-          <small>{{ subteam }}</small>
+          <div><small>{{ title }}</small></div>
+          <div><small>{{ team }}</small></div>
+          <div><small>{{ subteam }}</small></div>
         </p>
         <slot name="icons" />
       </footer>

--- a/components/base/DPersonCard.vue
+++ b/components/base/DPersonCard.vue
@@ -31,7 +31,8 @@
         <h5>{{ name }}</h5>
         <p data-testid="title-team">
           <small>{{ title }}</small>
-          <small v-scroll-to="'#our-teams'">{{ team }} | {{ subteam }}</small>
+          <small>{{ team }}</small>
+          <small>{{ subteam }}</small>
         </p>
         <slot name="icons" />
       </footer>

--- a/components/base/DPersonCard.vue
+++ b/components/base/DPersonCard.vue
@@ -87,7 +87,7 @@ export default {
       hover: false,
       teamIconArray: {
         'Computational Biology Core': 'mdi-dna',
-        'Graphics, Software and Data Core': 'mdi-graph',
+        'Graphics, Software, and Data Core': 'mdi-graph',
         'High-Performance Computing': 'mdi-server',
         'High-Performance Computing Systems': 'mdi-server-network',
         'Research Technical Services': 'mdi-earth'

--- a/components/base/DPersonCard.vue
+++ b/components/base/DPersonCard.vue
@@ -32,7 +32,9 @@
         <p data-testid="title-team">
           <div><small>{{ title }}</small></div>
           <div><small>{{ team }}</small></div>
-          <div><small>{{ subteam }}</small></div>
+          <div><small>{{ subteam }}</small></div><span class="icon" :class="[`has-text-${accent}`]">
+            <i :class="['icon mdi', `${teamIcon(subteam)}`]" />
+          </span>
         </p>
         <slot name="icons" />
       </footer>
@@ -83,7 +85,19 @@ export default {
     return {
       active: false,
       hover: false,
+      teamIconArray: {
+        'Computational Biology Core': 'mdi-dna',
+        'Graphics, Software and Data Core': 'mdi-graph',
+        'High-Performance Computing': 'mdi-server',
+        'High-Performance Computing Systems': 'mdi-server-network',
+        'Research Technical Services': 'mdi-earth'
+      },
     };
+  },
+  methods: {
+    teamIcon(team) {
+      return this.teamIconArray[team];
+    },
   },
 };
 </script>

--- a/components/base/DPersonCard.vue
+++ b/components/base/DPersonCard.vue
@@ -17,6 +17,7 @@
         @blur="active = false"
         @mouseover="active = true"
         @mouseout="active = false"
+        @click="$router.push(`/people/${name}`)"
       >
         <img
           :alt="'Picture of' + name"
@@ -28,11 +29,11 @@
     </template>
     <template #footer>
       <footer class="content py-3 px-3">
-        <h5>{{ name }}</h5>
+        <h5 @click="$router.push(`/people/${name}`)">{{ name }}</h5>
         <p data-testid="title-team">
           <div><small>{{ title }}</small></div>
           <div><small>{{ team }}</small></div>
-          <div><small>{{ subteam }}</small></div><span class="icon" :class="[`has-text-${accent}`]">
+          <div><small>{{ subteam }}</small></div><span class="icon" :class="[`has-text-${accent}`]" @click="scrollToElement(subteam)">
             <i :class="['icon mdi', `${teamIcon(subteam)}`]" />
           </span>
         </p>
@@ -92,11 +93,21 @@ export default {
         'High-Performance Computing Systems': 'mdi-server-network',
         'Research Technical Services': 'mdi-earth'
       },
+      teamElementArray: {
+        'Computational Biology Core': 'computational-biology-core',
+        'Graphics, Software, and Data Core': 'graphics-software-and-data-core',
+        'High-Performance Computing': 'high-performance-computing',
+        'High-Performance Computing Systems': 'high-performance-computing-systems',
+        'Research Technical Services': 'research-technical-services'
+      },
     };
   },
   methods: {
     teamIcon(team) {
       return this.teamIconArray[team];
+    },
+    scrollToElement(team) {
+      document.getElementById(this.teamElementArray[team]).scrollIntoView();
     },
   },
 };

--- a/components/blocks/About.vue
+++ b/components/blocks/About.vue
@@ -78,6 +78,7 @@
             :name="person.name"
             :title="person.title"
             :team="person.team"
+            :subteam="person.subteam"
             :main-image="'/content/images/people/' + person.image"
             :hover-image="
               '/content/images/people/' + person.image.replace('main', 'hover')

--- a/components/blocks/About.vue
+++ b/components/blocks/About.vue
@@ -83,7 +83,6 @@
             :hover-image="
               '/content/images/people/' + person.image.replace('main', 'hover')
             "
-            @click.native="$router.push(`/people/${person.name}`)"
           >
             <template #icons>
               <a

--- a/components/blocks/About.vue
+++ b/components/blocks/About.vue
@@ -68,12 +68,11 @@
         </client-only>
         <!-- People -->
         <div v-if="item.title === 'People'" class="card-group">
-          {{ teamSort }}
           <DPersonCard
             v-for="person in teamSort"
             :key="urlize(person.name)"
             variant="white"
-            accent="warning"
+            :accent="teamColor()[person.subteam]"
             width="xsmall"
             class="mx-1 my-1"
             :name="person.name"
@@ -117,7 +116,7 @@
 <script>
 import DTOC from '@/components/base/DTableOfContents.vue';
 import DPersonCard from '@/components/base/DPersonCard.vue';
-import { urlize } from '@/utils';
+import { COLOR_VARIANTS, urlize } from '@/utils';
 
 export default {
   components: {
@@ -154,7 +153,6 @@ export default {
         return sortOrder.indexOf(a.slug) - sortOrder.indexOf(b.slug);
       });
     },
-
     tocData() {
       return this.sortedData.map((d, i) => {
         return {
@@ -164,7 +162,6 @@ export default {
         };
       });
     },
-
     orderedPeople() {
       const d = this.data;
       const people = [...d.find((d) => d.title === 'People').data];
@@ -190,6 +187,15 @@ export default {
   },
   methods: {
     urlize,
+    teamColor() {
+      const numTeams = this.teams[1].length;
+      const colors = COLOR_VARIANTS.slice(2, numTeams + 2);
+      const obj = {};
+      this.teams[1].forEach((k, i) => {
+        obj[k] = colors[i];
+      });
+      return obj;
+    },
   },
 };
 </script>

--- a/components/blocks/About.vue
+++ b/components/blocks/About.vue
@@ -68,8 +68,9 @@
         </client-only>
         <!-- People -->
         <div v-if="item.title === 'People'" class="card-group">
+          {{ teamSort }}
           <DPersonCard
-            v-for="person in orderedPeople"
+            v-for="person in teamSort"
             :key="urlize(person.name)"
             variant="white"
             accent="warning"
@@ -169,6 +170,22 @@ export default {
       const people = [...d.find((d) => d.title === 'People').data];
       people.sort((a, b) => (a.name > b.name ? 1 : -1));
       return people;
+    },
+    teams() {
+      const teams = [...new Set(this.orderedPeople.map((x) => x.team))];
+      const subteams = [...new Set(this.orderedPeople.map((x) => x.subteam))];
+      teams.sort((a, b) => (a > b ? 1 : -1));
+      subteams.sort((a, b) => (a > b ? 1 : -1));
+      return [teams, subteams];
+    },
+    teamSort() {
+      const d = this.orderedPeople;
+      d.sort((a, b) => {
+        return (
+          this.teams[1].indexOf(a.subteam) - this.teams[1].indexOf(b.subteam)
+        );
+      });
+      return d;
     },
   },
   methods: {

--- a/components/blocks/About.vue
+++ b/components/blocks/About.vue
@@ -99,7 +99,7 @@
                   person.brown_directory_uuid
                 "
                 aria-label="information icon"
-                ><span class="icon"><i class="mdi mdi-information" /></span>
+                ><span class="icon"><i class="mdi mdi-email" /></span>
               </a>
             </template>
           </DPersonCard>

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -6,7 +6,7 @@
         $route.params.main === 'services' ||
         ($route.params.main === 'our-work' && !$route.params.category)
       "
-      class="÷ card-container is-flex mt-6 is-justify-content-space-evenly is-flex-wrap-wrap"
+      class="card-container is-flex mt-6 is-justify-content-space-evenly is-flex-wrap-wrap"
     >
       <DCard
         v-for="(item, i) in filteredData"

--- a/components/blocks/FilesToCards.vue
+++ b/components/blocks/FilesToCards.vue
@@ -6,12 +6,7 @@
         $route.params.main === 'services' ||
         ($route.params.main === 'our-work' && !$route.params.category)
       "
-      class="
-        card-container
-        is-flex
-        mt-6
-        is-justify-content-space-evenly is-flex-wrap-wrap
-      "
+      class="÷ card-container is-flex mt-6 is-justify-content-space-evenly is-flex-wrap-wrap"
     >
       <DCard
         v-for="(item, i) in filteredData"
@@ -46,14 +41,7 @@
                 link.target.startsWith('mailto')
               "
               :href="link.target"
-              class="
-                m-1
-                link-item
-                d-button
-                has-background-link has-text-white has-text-weight-semibold
-                is-size-5
-                link-button
-              "
+              class="m-1 link-item d-button has-background-link has-text-white has-text-weight-semibold is-size-5 link-button"
             >
               {{ link.text.toUpperCase() }}
               <span class="icon ml-2">
@@ -63,14 +51,7 @@
             <nuxt-link
               v-else
               :to="link.target"
-              class="
-                m-1
-                link-item
-                d-button
-                has-background-link has-text-white has-text-weight-semibold
-                is-size-5
-                link-button
-              "
+              class="m-1 link-item d-button has-background-link has-text-white has-text-weight-semibold is-size-5 link-button"
             >
               {{ link.text.toUpperCase() }}
               <span class="icon ml-2">
@@ -83,22 +64,16 @@
     </div>
     <div v-else class="container">
       <div
-        class="
-          multiselect-header
-          mt-4
-          mb-1
-          is-flex is-flex-wrap-wrap is-justify-content-space-evenly
-        "
+        class="multiselect-header mt-4 mb-1 is-flex is-flex-wrap-wrap is-justify-content-space-evenly"
       >
         Filter cards by:
       </div>
       <div
-        class="
-          dropdown
-          is-flex is-flex-wrap-wrap is-justify-content-space-evenly
-        "
+        class="dropdown is-flex is-flex-wrap-wrap is-justify-content-space-evenly"
       >
-        <div class="mb-1 is-flex is-justify-content-space-evenly is-flex-wrap-wrap">
+        <div
+          class="mb-1 is-flex is-justify-content-space-evenly is-flex-wrap-wrap"
+        >
           <div
             v-for="(cat, index) in tagCategories"
             :key="cat"
@@ -127,22 +102,14 @@
         <button class="ml-1 button is-normal is-warning" @click="clearAll">
           Clear Filters
         </button>
-    </div>
+      </div>
       <div
-        class="
-          multiselect-header
-          mt-5
-          mb-1
-          is-flex is-flex-wrap-wrap is-justify-content-space-evenly
-        "
+        class="multiselect-header mt-5 mb-1 is-flex is-flex-wrap-wrap is-justify-content-space-evenly"
       >
         Sort cards by:
       </div>
       <div
-        class="
-          dropdown
-          is-flex is-flex-wrap-wrap is-justify-content-space-evenly
-        "
+        class="dropdown is-flex is-flex-wrap-wrap is-justify-content-space-evenly"
       >
         <div class="mb-1 is-flex">
           <multiselect
@@ -167,12 +134,7 @@
         </div>
       </div>
       <div
-        class="
-          card-container
-          is-flex
-          mt-6
-          is-justify-content-space-evenly is-flex-wrap-wrap
-        "
+        class="card-container is-flex mt-6 is-justify-content-space-evenly is-flex-wrap-wrap"
       >
         <DCard
           v-for="(item, i) in sortedArray"
@@ -231,14 +193,7 @@
               <a
                 v-for="link in item.links"
                 :key="link.url"
-                class="
-                  m-1
-                  link-item
-                  d-button
-                  has-background-link has-text-white has-text-weight-semibold
-                  is-size-5
-                  link-button
-                "
+                class="m-1 link-item d-button has-background-link has-text-white has-text-weight-semibold is-size-5 link-button"
                 :href="link.url"
               >
                 <span>{{ link.category.toUpperCase() }} </span>
@@ -336,10 +291,12 @@ export default {
       for (let i=0; i < this.searchGroup.length; i++) {
         if (this.searchGroup[i] && this.searchGroup[i].length > 0) {
           filtered = filtered.filter((card) => {
-            return this.searchGroup[i].map(name => name.tagCode).some((tag) =>
-              this.tags.some((tagType) => {
-                const tags = card[tagType] ?? [];
-                return tags.includes(tag);
+            return this.searchGroup[i]
+              .map((name) => name.tagCode)
+              .some((tag) =>
+                this.tags.some((tagType) => {
+                  const tags = card[tagType] ?? [];
+                  return tags.includes(tag);
                 })
               );
           });
@@ -394,12 +351,14 @@ export default {
         .map((tagType) => this.filteredData.map((card) => card[tagType]))
         .flat(2)
         .filter((e) => e);
-      const names = tags.filter((tag, index) => tags.indexOf(tag) === index).sort();
-      const tagCodes = names.map(item => humanizeHero(item))
+      const names = tags
+        .filter((tag, index) => tags.indexOf(tag) === index)
+        .sort();
+      const tagCodes = names.map((item) => humanizeHero(item));
       const res = []
       names.forEach((n, index) => {
         const code = tagCodes[index];
-        res.push({name: code, tagCode: n})
+        res.push({ name: code, tagCode: n });
       });
       return res;
     },

--- a/pages/people/_people.vue
+++ b/pages/people/_people.vue
@@ -17,7 +17,10 @@
             <h2 class="title has-text-black pt-6">{{ person.name }}</h2>
             <h2 class="subtitle has-text-black">{{ person.title }}</h2>
             <h2 class="subtitle has-text-black">
-              {{ person.team }} | {{ person.subteam }}
+              {{ person.team }}
+            </h2>
+            <h2 class="subtitle has-text-black">
+              {{ person.subteam }}
             </h2>
             <a
               v-if="person.github_username"
@@ -35,7 +38,7 @@
               "
               aria-label="information icon"
               ><span class="icon is-large"
-                ><i class="mdi mdi-48px mdi-information"
+                ><i class="mdi mdi-48px mdi-email"
               /></span>
             </a>
           </div>


### PR DESCRIPTION
This PR adds team sorting to the current alphabetical order of CCV staff.

- [x]  sort by team
- [x] change accent colors for teams
- [x] change cards to show subteam and team
- [x] add scroll up to team description (icon next to subteam)
- [x] back button from person detail takes you to bottom of About page, but link is to #people (maybe fixed in nuxt3)
- [x] change info icon to email