### PR TITLE
refactor: info

### DIFF
--- a/components/storage/MultipleChoice.vue
+++ b/components/storage/MultipleChoice.vue
@@ -19,8 +19,8 @@
     </span>
     <details v-if="question.information" class="question-details mb-4">
       <summary>
-        <span class="icon has-text-info">
-          <i class="mdi mdi-information" />
+        <span class="icon has-text-info is-medium">
+          <i class="mdi mdi-information-outline mdi-24px" />
         </span>
       </summary>
       <div class="content" v-html="$md.render(question.information)"></div>

--- a/components/storage/MultipleChoice.vue
+++ b/components/storage/MultipleChoice.vue
@@ -20,7 +20,7 @@
     <details v-if="question.information" class="question-details mb-4">
       <summary>
         <span class="icon has-text-info">
-          <i class="mdi mdi-information-outline" />
+          <i class="mdi mdi-information" />
         </span>
       </summary>
       <div class="content" v-html="$md.render(question.information)"></div>


### PR DESCRIPTION
> Make the ‘Info’ icons on the comparison page larger. Depending on the screen size, these icons can be very difficult to notice.

<img width="573" alt="Screenshot 2024-08-23 at 4 56 20 PM" src="https://github.com/user-attachments/assets/46392470-5d0e-42f2-bdf5-612f49b8b4d4">
