### PR TITLE
chore: new accordion design for storage page

### DIFF
--- a/components/base/Accordion.vue
+++ b/components/base/Accordion.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <div
-      class="card has-background-"
-      :class="{ 'not-expanded': !expanded, 'has-background-': backgroundColor }"
+      class="card has-background-info"
+      :class="{ 'not-expanded': !expanded}"
     >
       <header class="card-header" @click="toggleCardState">
         <p class="card-header-title">
@@ -10,7 +10,7 @@
         </p>
         <a class="card-header-icon">
           <span class="icon">
-            <i class="mdi mdi-information-outline mdi-24px" />
+            <i class="mdi mdi-menu-up mdi-24px" />
           </span>
         </a>
       </header>

--- a/components/base/Accordion.vue
+++ b/components/base/Accordion.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="column is-half">
+    <div class="card" :class="{ 'not-expanded': !this.expanded }">
+      <header class="card-header" @click="toggleCardState">
+        <p class="card-header-title">
+          {{title}}
+        </p>
+        <a class="card-header-icon">
+            <span class="icon">
+              <i class="fa fa-angle-up"></i>
+            </span>
+        </a>
+      </header>
+
+      <div class="card-content">
+        <div class="content">
+          <slot></slot>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    title: String,
+    expandAll: Boolean
+  },
+  data() {
+    return {
+      expanded: false,
+    };
+  },
+  methods: {
+    toggleCardState() {
+      this.expanded = !this.expanded;
+    },
+    closeAll() {
+      this.expanded = false;
+    }
+  },
+
+};
+</script>

--- a/components/base/Accordion.vue
+++ b/components/base/Accordion.vue
@@ -1,13 +1,16 @@
 <template>
   <div>
-    <div class="card" :class="{ 'not-expanded': !expanded }">
+    <div
+      class="card has-background-"
+      :class="{ 'not-expanded': !expanded, 'has-background-': backgroundColor }"
+    >
       <header class="card-header" @click="toggleCardState">
         <p class="card-header-title">
           {{ title }}
         </p>
         <a class="card-header-icon">
           <span class="icon">
-            <i class="fa fa-angle-up"></i>
+            <i class="mdi mdi-information-outline mdi-24px" />
           </span>
         </a>
       </header>
@@ -25,6 +28,7 @@
 export default {
   props: {
     title: String,
+    backgroundColor: String,
     expandAll: Boolean,
   },
   data() {

--- a/components/base/Accordion.vue
+++ b/components/base/Accordion.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="column is-half">
+  <div>
     <div class="card" :class="{ 'not-expanded': !expanded }">
       <header class="card-header" @click="toggleCardState">
         <p class="card-header-title">
@@ -42,3 +42,38 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.card {
+  margin-bottom: 10px;
+  width: 100%;
+
+  .card-header {
+    cursor: pointer;
+
+    .icon {
+      transform: rotate(180deg);
+      transition: transform 150ms ease-out;
+    }
+  }
+
+  .card-content {
+    transition: all 150ms ease;
+  }
+}
+
+.card.not-expanded {
+  .card-header {
+    .icon {
+      transform: rotate(0deg);
+    }
+  }
+  .card-content {
+    transform: scaleY(0);
+    transform-origin: top;
+    opacity: 0;
+    height: 0;
+    padding: 0;
+  }
+}
+</style>

--- a/components/base/Accordion.vue
+++ b/components/base/Accordion.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="column is-half">
-    <div class="card" :class="{ 'not-expanded': !this.expanded }">
+    <div class="card" :class="{ 'not-expanded': !expanded }">
       <header class="card-header" @click="toggleCardState">
         <p class="card-header-title">
-          {{title}}
+          {{ title }}
         </p>
         <a class="card-header-icon">
-            <span class="icon">
-              <i class="fa fa-angle-up"></i>
-            </span>
+          <span class="icon">
+            <i class="fa fa-angle-up"></i>
+          </span>
         </a>
       </header>
 
@@ -17,7 +17,6 @@
           <slot></slot>
         </div>
       </div>
-
     </div>
   </div>
 </template>
@@ -26,7 +25,7 @@
 export default {
   props: {
     title: String,
-    expandAll: Boolean
+    expandAll: Boolean,
   },
   data() {
     return {
@@ -39,8 +38,7 @@ export default {
     },
     closeAll() {
       this.expanded = false;
-    }
+    },
   },
-
 };
 </script>

--- a/components/base/Accordion.vue
+++ b/components/base/Accordion.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      class="card has-background-info"
+      class="card has-background-info is-hoverable"
       :class="{ 'not-expanded': !expanded}"
     >
       <header class="card-header" @click="toggleCardState">
@@ -9,8 +9,11 @@
           {{ title }}
         </p>
         <a class="card-header-icon">
-          <span class="icon">
-            <i class="mdi mdi-menu-up mdi-24px" />
+          <span v-if="expanded === false" class="icon">
+            <i class="mdi mdi-plus mdi-24px" />
+          </span>
+          <span v-else class="icon">
+            <i class="mdi mdi-minus mdi-24px" />
           </span>
         </a>
       </header>
@@ -28,7 +31,6 @@
 export default {
   props: {
     title: String,
-    backgroundColor: String,
     expandAll: Boolean,
   },
   data() {
@@ -54,11 +56,6 @@ export default {
 
   .card-header {
     cursor: pointer;
-
-    .icon {
-      transform: rotate(180deg);
-      transition: transform 150ms ease-out;
-    }
   }
 
   .card-content {

--- a/components/base/Accordion.vue
+++ b/components/base/Accordion.vue
@@ -9,11 +9,11 @@
           {{ title }}
         </p>
         <a class="card-header-icon">
-          <span v-if="expanded === false" class="icon">
-            <i class="mdi mdi-plus mdi-24px" />
+          <span v-if="expanded" class="icon">
+            <i class="mdi mdi-minus mdi-24px" />
           </span>
           <span v-else class="icon">
-            <i class="mdi mdi-minus mdi-24px" />
+            <i class="mdi mdi-plus mdi-24px" />
           </span>
         </a>
       </header>

--- a/components/storage/ServiceSelection.vue
+++ b/components/storage/ServiceSelection.vue
@@ -30,16 +30,10 @@
                 ]"
             /></span>
           </button>
-          <p class="is-size-5 has-text-bold">{{ humanize(s.name) }}</p>
+          <Accordion title="{{humanize(s.name)}}">
+            <div class="content" v-html="$md.render(s.description || '')"></div>
+          </Accordion>
         </div>
-        <details v-if="s.description" class="service-details mb-4 ml-4">
-          <summary>
-            <span class="icon is-medium">
-              <i class="mdi mdi-information mdi-24px" />
-            </span>
-          </summary>
-          <div class="content" v-html="$md.render(s.description || '')"></div>
-        </details>
       </div>
     </div>
   </div>
@@ -47,8 +41,13 @@
 
 <script>
 import { humanize } from '@/utils';
+import Accordion from '~/components/base/Accordion.vue';
 
 export default {
+  comments: {
+    Accordion,
+  },
+  components: { Accordion },
   props: {
     services: {
       type: Array,

--- a/components/storage/ServiceSelection.vue
+++ b/components/storage/ServiceSelection.vue
@@ -10,7 +10,7 @@
           matchingServices[i] ? 'has-background-info' : 'has-background-light',
         ]"
       >
-        <div class="is-flex">
+        <div class="is-flex is-align-items-center">
           <button
             class="button-nostyle"
             type="button"
@@ -30,7 +30,7 @@
                 ]"
             /></span>
           </button>
-          <Accordion :title="humanize(s.name)">
+          <Accordion :title="humanize(s.name)" background-color="info">
             <div class="content" v-html="$md.render(s.description || '')"></div>
           </Accordion>
         </div>

--- a/components/storage/ServiceSelection.vue
+++ b/components/storage/ServiceSelection.vue
@@ -10,7 +10,7 @@
           matchingServices[i] ? 'has-background-info' : 'has-background-light',
         ]"
       >
-        <div>
+        <div class="is-flex">
           <button
             class="button-nostyle"
             type="button"
@@ -30,7 +30,7 @@
                 ]"
             /></span>
           </button>
-          <Accordion title="{{humanize(s.name)}}">
+          <Accordion :title="humanize(s.name)">
             <div class="content" v-html="$md.render(s.description || '')"></div>
           </Accordion>
         </div>

--- a/components/storage/ServiceSelection.vue
+++ b/components/storage/ServiceSelection.vue
@@ -30,7 +30,7 @@
                 ]"
             /></span>
           </button>
-          <Accordion :title="humanize(s.name)" background-color="info">
+          <Accordion :title="humanize(s.name)">
             <div class="content" v-html="$md.render(s.description || '')"></div>
           </Accordion>
         </div>

--- a/pages/storage.vue
+++ b/pages/storage.vue
@@ -84,7 +84,7 @@
       </p>
     </div>
     <div class="is-flex is-flex-wrap-wrap is-justify-content-center mb-6">
-      <a href="https://brown.atlassian.net/servicedesk/customer/portal/16/group/55/create/218">
+      <a href="https://brown.atlassian.net/servicedesk/customer/portal/16/group/55/create/263">
         <DButton
           type="button"
           name="Request Storage"


### PR DESCRIPTION
https://qa-ccv-brown-edu--pr157-accordion-design-z5c51sjs.web.app/storage

Feedback from team: "One suggestion stood out: not everybody is figuring out that the arrows (bullets) used in 'Brown Storage Options' are actually dropdowns to get more information. Can we change them to 'Chevron up/down' icons OR '+/— in a circle' icon preceding the text?"

I made the entire storage-option its own separate box that is hoverable with a pointer -- do we think this new design effectively addresses their issue?