### PR TITLE
fix: build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "bulma": "^0.9.3",
         "bulma-checkradio": "^1.1.1",
         "express": "^4.17.1",
-        "fibers": "^5.0.0",
         "graphql": "^15.5.0",
         "graphql-request": "^3.4.0",
         "nuxt": "^2.15.6",
@@ -11464,6 +11463,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -13401,7 +13403,10 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.3.tgz",
       "integrity": "sha512-/qYTSoZydQkM21qZpGLDLuCq8c+B8KhuCQ1kLPvnRNhxhVbvrpmH9l2+Lblf5neDuEsY4bfT7LeO553TXQDvJw==",
+      "dev": true,
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -37844,7 +37849,10 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "devalue": {
       "version": "2.0.1",
@@ -39368,6 +39376,9 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.3.tgz",
       "integrity": "sha512-/qYTSoZydQkM21qZpGLDLuCq8c+B8KhuCQ1kLPvnRNhxhVbvrpmH9l2+Lblf5neDuEsY4bfT7LeO553TXQDvJw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "detect-libc": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "bulma": "^0.9.3",
     "bulma-checkradio": "^1.1.1",
     "express": "^4.17.1",
-    "fibers": "^5.0.0",
     "graphql": "^15.5.0",
     "graphql-request": "^3.4.0",
     "nuxt": "^2.15.6",


### PR DESCRIPTION
* Removes `fibers` as a direct dependency. We don't import it anywhere in the code directly and it seems to be causing issues.

`fibers` is still a peer dependency for the version of `sass-loader` we have, but it doesn't seem to be causing issues at the moment. 

> [!NOTE]  
> This PR is a quick fix for the build issues for this repo and does not update everything. This repo's packages are outdated.
> This repo currently uses node 16 which should be updated to like node 20 or 22 LTS. Though... we are working on a new website.


#### Original Error Message 
from [build_and_deploy](https://github.com/brown-ccv/ccv-website-nuxt/actions/runs/12795090776/job/35671667648)

```shell 
Run npm ci
npm WARN deprecated vue-analytics@5.22.1: Sorry but vue-analytics is no longer maintained. I would suggest you switch to vue-gtag, with love, the guy who made the package.
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated tweetsodium@0.0.5: tweetsodium is deprecated and unmaintained. Please consider using libsodium.js, maintained by the same author as libsodium: https://github.com/jedisct1/libsodium.js
npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
npm WARN deprecated source-map-url@0.[4](https://github.com/brown-ccv/ccv-website-nuxt/actions/runs/12795090776/job/35671667648#step:5:5).1: See https://github.com/lydell/source-map-url#deprecated
npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm WARN deprecated topojson@3.0.2: Use topojson-client, topojson-server or topojson-simplify directly.
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated svgo@1.3.2: This SVGO version is no longer supported. Upgrade to v2.x.x.
npm WARN deprecated har-validator@[5](https://github.com/brown-ccv/ccv-website-nuxt/actions/runs/12795090776/job/35671667648#step:5:6).1.5: this library is no longer supported
npm WARN deprecated babel-eslint@10.1.0: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
npm WARN deprecated @types/webpack-dev-middleware@5.3.0: This is a stub types definition. webpack-dev-middleware provides its own type definitions, so you do not need this installed.
npm WARN deprecated @stylelint/postcss-markdown@0.3[6](https://github.com/brown-ccv/ccv-website-nuxt/actions/runs/12795090776/job/35671667648#step:5:7).2: Use the original unforked package instead: postcss-markdown
npm WARN deprecated @stylelint/postcss-css-in-js@0.37.3: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm WARN deprecated @types/browserslist@4.15.0: This is a stub types definition. browserslist provides its own type definitions, so you do not need this installed.
npm WARN deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
npm WARN deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
npm WARN deprecated uuid@3.4.0: Please upgrade  to version [7](https://github.com/brown-ccv/ccv-website-nuxt/actions/runs/12795090776/job/35671667648#step:5:8) or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v[8](https://github.com/brown-ccv/ccv-website-nuxt/actions/runs/12795090776/job/35671667648#step:5:9).dev/blog/math-random for details.
npm ERR! code 127
npm ERR! path /home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/fibers
npm ERR! command failed
npm ERR! command sh -c -- node build.js || nodejs build.js
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@7.1.2
npm ERR! gyp info using node@16.20.2 | linux | x64
npm ERR! gyp info find Python using Python version 3.12.3 found at "/usr/bin/python3"
npm ERR! gyp http GET https://nodejs.org/download/release/v16.20.2/node-v16.20.2-headers.tar.gz
npm ERR! gyp http 200 https://nodejs.org/download/release/v16.20.2/node-v16.20.2-headers.tar.gz
npm ERR! gyp http GET https://nodejs.org/download/release/v16.20.2/SHASUMS256.txt
npm ERR! gyp http 200 https://nodejs.org/download/release/v16.20.2/SHASUMS256.txt
npm ERR! (node:21[9](https://github.com/brown-ccv/ccv-website-nuxt/actions/runs/12795090776/job/35671667648#step:5:10)6) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
npm ERR! (Use `node --trace-deprecation ...` to show where the warning was created)
npm ERR! gyp info spawn /usr/bin/python3
npm ERR! gyp info spawn args [
npm ERR! gyp info spawn args   '/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/gyp/gyp_main.py',
npm ERR! gyp info spawn args   'binding.gyp',
npm ERR! gyp info spawn args   '-f',
npm ERR! gyp info spawn args   'make',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/fibers/build/config.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/addon.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/home/runner/.cache/node-gyp/16.20.2/include/node/common.gypi',
npm ERR! gyp info spawn args   '-Dlibrary=shared_library',
npm ERR! gyp info spawn args   '-Dvisibility=default',
npm ERR! gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.20.2',
npm ERR! gyp info spawn args   '-Dnode_gyp_dir=/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp',
npm ERR! gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.20.2/<(target_arch)/node.lib',
npm ERR! gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/fibers',
npm ERR! gyp info spawn args   '-Dnode_engine=v8',
npm ERR! gyp info spawn args   '--depth=.',
npm ERR! gyp info spawn args   '--no-parallel',
npm ERR! gyp info spawn args   '--generator-output',
npm ERR! gyp info spawn args   'build',
npm ERR! gyp info spawn args   '-Goutput_dir=.'
npm ERR! gyp info spawn args ]
npm ERR! Traceback (most recent call last):
npm ERR!   File "/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/gyp/gyp_main.py", line 51, in <module>
npm ERR!     sys.exit(gyp.script_main())
npm ERR!              ^^^^^^^^^^^^^^^^^
npm ERR!   File "/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 670, in script_main
npm ERR!     return main(sys.argv[1:])
npm ERR!            ^^^^^^^^^^^^^^^^^^
npm ERR!   File "/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 662, in main
npm ERR!     return gyp_main(args)
npm ERR!            ^^^^^^^^^^^^^^
npm ERR!   File "/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 629, in gyp_main
npm ERR!     [generator, flat_list, targets, data] = Load(
npm ERR!                                             ^^^^^
npm ERR!   File "/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 150, in Load
npm ERR!     result = gyp.input.Load(
npm ERR!              ^^^^^^^^^^^^^^^
npm ERR!   File "/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 3021, in Load
npm ERR!     LoadTargetBuildFile(
npm ERR!   File "/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 411, in LoadTargetBuildFile
npm ERR!     build_file_data = LoadOneBuildFile(
npm ERR!                       ^^^^^^^^^^^^^^^^^
npm ERR!   File "/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 239, in LoadOneBuildFile
npm ERR!     build_file_contents = open(build_file_path, "rU").read()
npm ERR!                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
npm ERR! ValueError: invalid mode: 'rU' while trying to load binding.gyp
npm ERR! gyp ERR! configure error 
npm ERR! gyp ERR! stack Error: `gyp` failed with exit code: 1
npm ERR! gyp ERR! stack     at ChildProcess.onCpExit (/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/node-gyp/lib/configure.js:351:16)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:293:12)
npm ERR! gyp ERR! System Linux 6.8.0-[10](https://github.com/brown-ccv/ccv-website-nuxt/actions/runs/12795090776/job/35671667648#step:5:11)17-azure
npm ERR! gyp ERR! command "/opt/hostedtoolcache/node/16.20.2/x64/bin/node" "/home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/.bin/node-gyp" "rebuild" "--release"
npm ERR! gyp ERR! cwd /home/runner/work/ccv-website-nuxt/ccv-website-nuxt/node_modules/fibers
npm ERR! gyp ERR! node -v v16.20.2
npm ERR! gyp ERR! node-gyp -v v7.1.2
npm ERR! gyp ERR! not ok 
npm ERR! node-gyp exited with code: 1
npm ERR! Please make sure you are using a supported platform and node version. If you
npm ERR! would like to compile fibers on this machine please make sure you have setup your
npm ERR! build environment--
npm ERR! Windows + OS X instructions here: https://github.com/nodejs/node-gyp
npm ERR! Ubuntu users please run: `sudo apt-get install g++ build-essential`
npm ERR! RHEL users please run: `yum install gcc-c++` and `yum groupinstall 'Development Tools'` 
npm ERR! Alpine users please run: `sudo apk add python make g++`
npm ERR! sh: 1: nodejs: not found

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2025-01-15T18_54_26_866Z-debug-0.log
Error: Process completed with exit code [12](https://github.com/brown-ccv/ccv-website-nuxt/actions/runs/12795090776/job/35671667648#step:5:13)7.
```